### PR TITLE
ci: publish to npmjs.org via OIDC trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,7 @@ permissions:
   issues: write
   pull-requests: write
   packages: write
+  id-token: write # npm trusted publishing (OIDC) to npmjs.org
 
 jobs:
   release:
@@ -41,8 +42,12 @@ jobs:
 
       - run: yarn release
 
+      # OIDC trusted publishing requires npm >= 11.5.1; setup-node's bundled npm may lag behind
+      - run: npm install --global npm@latest
+
       # cannot run this on branches because it doesn't keep the canary version from auto shipit, can only secondarily publish to npm for main branch
       - name: Publish secondarily to npm
+        # Auth for npmjs.org is OIDC trusted publishing (id-token above), not NPM_TOKEN; npm auto-generates provenance.
         # waiting on bug/related pr/auto release https://github.com/intuit/auto/issues/2488
         # run: lerna exec --stream --parallel -- npm publish --access=public --ignore-scripts --@alienfast:registry='https://registry.npmjs.org'
         run: >


### PR DESCRIPTION
## Why

The `12.1.7` release published the corrected dist exports to **GitHub Packages**, but the **secondary npmjs.org publish 404'd**:

```
npm error 404 Not Found - PUT https://registry.npmjs.org/@alienfast%2flogger
```

A 404 on a scoped `PUT` is an auth failure — `NPM_TOKEN` was never wired to an `.npmrc` auth line for `registry.npmjs.org`, so the publish was unauthenticated.

## What

Switch the npmjs.org publish to **npm trusted publishing (OIDC)**:

- Add `id-token: write` permission so the runner can mint a GitHub OIDC token.
- Upgrade to `npm@latest` (OIDC trusted publishing needs npm ≥ 11.5.1).
- `npm publish` now authenticates via a short-lived OIDC token and auto-generates provenance — no long-lived `NPM_TOKEN`.

The publish commands themselves are unchanged.

## Requires (npmjs.com side)

A **trusted publisher** must be configured for each package before this merges:
`@alienfast/logger`, `@alienfast/logger-browser`, `@alienfast/logger-node` → repo `alienfast/logger`, workflow `release.yml` (no environment).

## Effect on merge

`auto` sees only a `ci:` commit → no version bump (stays `12.1.7`); the secondary step then publishes `12.1.7` to npmjs.org via OIDC, closing the gap left by the failed run.